### PR TITLE
remove spurious dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,13 @@ workflows:
   workflow:
     jobs:
       - go-test:
-          name: Go 1.14
-          docker-image: circleci/golang:1.13
+          name: Go 1.15
+          docker-image: circleci/golang:1.14
           run-lint: true
           with-coverage: true
       - go-test:
-          name: Go 1.13
-          docker-image: circleci/golang:1.13
+          name: Go 1.14
+          docker-image: circleci/golang:1.14
       - go-test-windows:
           name: Windows
       - benchmarks
@@ -35,11 +35,6 @@ jobs:
         environment:
           CIRCLE_TEST_REPORTS: /tmp/circle-reports
           CIRCLE_ARTIFACTS: /tmp/circle-artifacts
-          COMMON_GO_PACKAGES: >
-            github.com/golang/dep/cmd/dep
-            github.com/jstemmer/go-junit-report
-
-    working_directory: /go/src/gopkg.in/launchdarkly/go-server-sdk-evaluation.v1
 
     steps:
       - checkout
@@ -64,7 +59,6 @@ jobs:
           command: |
             mkdir -p $CIRCLE_TEST_REPORTS
             mkdir -p $CIRCLE_ARTIFACTS
-            trap "go-junit-report < $CIRCLE_ARTIFACTS/report.txt > $CIRCLE_TEST_REPORTS/junit.xml" EXIT
             make test | tee $CIRCLE_ARTIFACTS/report.txt
       
       - run:
@@ -96,21 +90,13 @@ jobs:
 
     environment:
       GOPATH: C:\Users\VssAdministrator\go
-      PACKAGE_PATH: github.com\launchdarkly\go-semver
 
     steps:
       - checkout
       - run: go version
       - run:
-          name: move source
-          command: |
-            go env GOPATH
-            mkdir ${env:GOPATH}\src\${env:PACKAGE_PATH}
-            mv * ${env:GOPATH}\src\${env:PACKAGE_PATH}\
-      - run:
           name: build and test
           command: |
-            cd ${env:GOPATH}\src\${env:PACKAGE_PATH}
             go get -t ./...
             go test -race ./...
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,11 +94,8 @@ jobs:
     steps:
       - checkout
       - run: go version
-      - run:
-          name: build and test
-          command: |
-            go get -t ./...
-            go test -race ./...
+      - run: go build ./...
+      - run: go test -race -v ./...
 
   benchmarks:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ benchmarks: build
 	@if grep <build/benchmarks.out '[1-9][0-9]* allocs/op'; then echo "Heap allocations detected in benchmarks!"; exit 1; fi
 
 test-coverage: $(COVERAGE_PROFILE_RAW)
-	if [ -z "$(which go-coverage-enforcer)" ]; then go install github.com/launchdarkly-labs/go-coverage-enforcer; fi
+	if [ -z "$(which go-coverage-enforcer)" ]; then go get -u github.com/launchdarkly-labs/go-coverage-enforcer; fi
 	go-coverage-enforcer -skipcode "// COVERAGE" -showcode -outprofile $(COVERAGE_PROFILE_FILTERED) $(COVERAGE_PROFILE_RAW)
 	go tool cover -html $(COVERAGE_PROFILE_FILTERED) -o $(COVERAGE_PROFILE_FILTERED_HTML)
 	go tool cover -html $(COVERAGE_PROFILE_RAW) -o $(COVERAGE_PROFILE_RAW_HTML)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This package has no external dependencies other than the regular Go runtime.
 
 ## Supported Go versions
 
-This version of the project has been tested with Go 1.13 through 1.14.
+This version of the project has been tested with Go 1.14 and above.
 
 ## Contributing
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/launchdarkly/go-semver
 
 go 1.13
 
-require (
-	github.com/launchdarkly-labs/go-coverage-enforcer v0.0.0-20200610003341-8bc77dea293c // indirect
-	github.com/stretchr/testify v1.6.1
-)
+require github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,16 +1,11 @@
-github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/launchdarkly-labs/go-coverage-enforcer v0.0.0-20200610003341-8bc77dea293c h1:efBUku8Iniz1FsNaOpr8Q2Nb3zqclxRcmLkyoskWxik=
-github.com/launchdarkly-labs/go-coverage-enforcer v0.0.0-20200610003341-8bc77dea293c/go.mod h1:fJXIR7UJYgdXVmLM40NGl/dbs2Smv+iESsaT9uC4v/s=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
The `go-coverage-enforcer` tool wasn't supposed to be installed as a dependency, just downloaded as part of a test step. It brought in some transitive stuff we don't want.