### PR TITLE
Use OctoSTS for raising PRs; upgrade actions; run zizmor

### DIFF
--- a/.github/actions/benchmarks/action.yml
+++ b/.github/actions/benchmarks/action.yml
@@ -14,7 +14,7 @@ runs:
 
     - name: Upload Results
       if: steps.benchmarks.outcome == 'success'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Benchmarks-${{ steps.go-version.outputs.version }}
         path: benchmarks.txt

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -31,11 +31,14 @@ runs:
     - name: Enforce coverage
       shell: bash
       run: |
-        if [ "${{ steps.test-coverage.outputs.coverage_status }}" != "0" ]; then
+        if [ "${STEPS_TEST_COVERAGE_OUTPUTS_COVERAGE_STATUS}" != "0" ]; then
           echo "Code isn't fully covered!"
-          if [ "${{ inputs.enforce }}" == "true" ]; then
+          if [ "${INPUTS_ENFORCE}" == "true" ]; then
             exit 1
           fi
         else 
           echo "Code is fully covered!"
         fi
+      env:
+        STEPS_TEST_COVERAGE_OUTPUTS_COVERAGE_STATUS: ${{ steps.test-coverage.outputs.coverage_status }}
+        INPUTS_ENFORCE: ${{ inputs.enforce }}

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -23,7 +23,7 @@ runs:
         echo "coverage_status=$status" >> $GITHUB_OUTPUT
 
     - name: Upload coverage results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Coverage-result-${{ steps.go-version.outputs.version }}
         path: build/coverage*

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -29,7 +29,7 @@ runs:
 
     - name: Upload test results
       if: steps.process-test.outcome == 'success'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: Test-result-${{ steps.go-version.outputs.version }}
         path: junit_report.xml

--- a/.github/launchdarkly/self.bump-go-versions.sts.yaml
+++ b/.github/launchdarkly/self.bump-go-versions.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:launchdarkly/go-semver:ref:refs/heads/main
+claim_pattern:
+  event_name: workflow_dispatch|schedule
+  ref: refs/heads/main
+  ref_protected: "true"
+  workflow_ref: launchdarkly/go-semver/.github/workflows/check-go-versions.yml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -36,8 +36,8 @@ jobs:
     needs: check-go-eol
     runs-on: ubuntu-slim
     env:
-      officialLatestVersion: ${{ needs.check-go-eol.outputs.latest }}
-      officialPenultimateVersion: ${{ needs.check-go-eol.outputs.penultimate }}
+      OFFICIAL_LATEST_VERSION: ${{ needs.check-go-eol.outputs.latest }}
+      OFFICIAL_PENULTIMATE_VERSION: ${{ needs.check-go-eol.outputs.penultimate }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -48,11 +48,11 @@ jobs:
         run:  cat ./.github/variables/go-versions.env > $GITHUB_OUTPUT
 
       - name: Update go-versions.env and README.md
-        if: steps.go-versions.outputs.latest != env.officialLatestVersion
+        if: steps.go-versions.outputs.latest != env.OFFICIAL_LATEST_VERSION
         id: update-go-versions
         run: |
-          sed -i -e "s#latest=[^ ]*#latest=${{ env.officialLatestVersion }}#g" \
-                 -e "s#penultimate=[^ ]*#penultimate=${{ env.officialPenultimateVersion }}#g" \
+          sed -i -e "s#latest=[^ ]*#latest=${OFFICIAL_LATEST_VERSION}#g" \
+                 -e "s#penultimate=[^ ]*#penultimate=${OFFICIAL_PENULTIMATE_VERSION}#g" \
                   ./.github/variables/go-versions.env
 
       - name: Create GitHub token
@@ -70,11 +70,11 @@ jobs:
           token: ${{ steps.github-token.outputs.token }}
           add-paths: |
             .github/variables/go-versions.env
-          branch: "launchdarklyreleasebot/update-to-go${{ env.officialLatestVersion }}-${{ matrix.branch }}"
+          branch: "launchdarklyreleasebot/update-to-go${{ env.OFFICIAL_LATEST_VERSION }}-${{ matrix.branch }}"
           author: "LaunchDarklyReleaseBot <LaunchDarklyReleaseBot@launchdarkly.com>"
           committer: "LaunchDarklyReleaseBot <LaunchDarklyReleaseBot@launchdarkly.com>"
           labels: ${{ matrix.branch }}
-          title: "fix(deps): bump supported Go versions to ${{ env.officialLatestVersion }} and ${{ env.officialPenultimateVersion }}"
-          commit-message: "Bumps from Go ${{ steps.go-versions.outputs.latest }} -> ${{ env.officialLatestVersion }} and ${{ steps.go-versions.outputs.penultimate }} -> ${{ env.officialPenultimateVersion }}."
+          title: "fix(deps): bump supported Go versions to ${{ env.OFFICIAL_LATEST_VERSION }} and ${{ env.OFFICIAL_PENULTIMATE_VERSION }}"
+          commit-message: "Bumps from Go ${{ steps.go-versions.outputs.latest }} -> ${{ env.OFFICIAL_LATEST_VERSION }} and ${{ steps.go-versions.outputs.penultimate }} -> ${{ env.OFFICIAL_PENULTIMATE_VERSION }}."
           body: |
             - [ ] I have triggered CI on this PR (either close & reopen this PR in Github UI, or `git commit -m "run ci" --allow-empty && git push`)

--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -4,19 +4,20 @@ on:
     - cron: "0 17 * * *"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   check-go-eol:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       latest: ${{ steps.parse.outputs.latest }}
       penultimate: ${{ steps.parse.outputs.penultimate }}
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v4
         # Perform a GET request to endoflife.date for the Go language. The response
         # contains all Go releases; we're interested in the 0'th and 1'th (latest and penultimate.)
       - name: Fetch officially supported Go versions
-        uses: JamesIves/fetch-api-data-action@396ebea7d13904824f85b892b1616985f847301c
+        uses: JamesIves/fetch-api-data-action@8dc51e982d982157bfd575ed64be3c48b3078037 # v2.5.0
         with:
           endpoint: https://endoflife.date/api/go.json
           configuration: '{ "method": "GET" }'
@@ -27,17 +28,21 @@ jobs:
         run: |
           echo "latest=${{ fromJSON(env.fetch-api-data)[0].cycle }}" >> $GITHUB_OUTPUT
           echo "penultimate=${{ fromJSON(env.fetch-api-data)[1].cycle }}" >> $GITHUB_OUTPUT
+
   create-prs:
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      id-token: write
     needs: check-go-eol
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     env:
       officialLatestVersion: ${{ needs.check-go-eol.outputs.latest }}
       officialPenultimateVersion: ${{ needs.check-go-eol.outputs.penultimate }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: Get current Go versions
         id: go-versions
         run:  cat ./.github/variables/go-versions.env > $GITHUB_OUTPUT
@@ -49,11 +54,20 @@ jobs:
           sed -i -e "s#latest=[^ ]*#latest=${{ env.officialLatestVersion }}#g" \
                  -e "s#penultimate=[^ ]*#penultimate=${{ env.officialPenultimateVersion }}#g" \
                   ./.github/variables/go-versions.env
+
+      - name: Create GitHub token
+        uses: launchdarkly/octosts-action@v1
+        if: steps.update-go-versions.outcome == 'success'
+        id: github-token
+        with:
+          scope: ${{ github.repository }}
+          identity: 'self.bump-go-versions'
+
       - name: Create pull request
         if: steps.update-go-versions.outcome == 'success'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.github-token.outputs.token }}
           add-paths: |
             .github/variables/go-versions.env
           branch: "launchdarklyreleasebot/update-to-go${{ env.officialLatestVersion }}-${{ matrix.branch }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     paths-ignore:
       - '**.md'
 
+permissions:
+  contents: read
+
 jobs:
   go-versions:
     uses: ./.github/workflows/go-versions.yml
@@ -35,9 +38,11 @@ jobs:
       matrix:
         go-version: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: 'false'
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
       - name: Test

--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -12,9 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     name: 'Unit Tests and Coverage'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: 'false'
       - name: Setup Go ${{ inputs.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ inputs.go-version }}
       - uses: ./.github/actions/unit-tests
@@ -28,9 +30,11 @@ jobs:
     name: 'Benchmarks'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: 'false'
       - name: Setup Go ${{ inputs.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ inputs.go-version }}
       - uses: ./.github/actions/benchmarks

--- a/.github/workflows/go-versions.yml
+++ b/.github/workflows/go-versions.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   go-versions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       latest: ${{ steps.set-env.outputs.latest }}
       penultimate: ${{ steps.set-env.outputs.penultimate }}
@@ -51,8 +51,12 @@ jobs:
       - name: Set Go Version Matrices
         id: set-matrix
         run: |
-          if [ "${{ steps.set-env.outputs.penultimate }}" == "${{ steps.set-env.outputs.min }}" ]; then
-            echo "all=[\"${{ steps.set-env.outputs.latest }}\",\"${{ steps.set-env.outputs.penultimate }}\"]" >> $GITHUB_OUTPUT
+          if [ "${STEPS_SET_ENV_OUTPUTS_PENULTIMATE}" == "${STEPS_SET_ENV_OUTPUTS_MIN}" ]; then
+            echo "all=[\"${STEPS_SET_ENV_OUTPUTS_LATEST}\",\"${STEPS_SET_ENV_OUTPUTS_PENULTIMATE}\"]" >> $GITHUB_OUTPUT
           else
-            echo "all=[\"${{ steps.set-env.outputs.latest }}\",\"${{ steps.set-env.outputs.penultimate }}\",\"${{ steps.set-env.outputs.min }}\"]" >> $GITHUB_OUTPUT
+            echo "all=[\"${STEPS_SET_ENV_OUTPUTS_LATEST}\",\"${STEPS_SET_ENV_OUTPUTS_PENULTIMATE}\",\"${STEPS_SET_ENV_OUTPUTS_MIN}\"]" >> $GITHUB_OUTPUT
           fi
+        env:
+          STEPS_SET_ENV_OUTPUTS_PENULTIMATE: ${{ steps.set-env.outputs.penultimate }}
+          STEPS_SET_ENV_OUTPUTS_MIN: ${{ steps.set-env.outputs.min }}
+          STEPS_SET_ENV_OUTPUTS_LATEST: ${{ steps.set-env.outputs.latest }}

--- a/.github/workflows/go-versions.yml
+++ b/.github/workflows/go-versions.yml
@@ -42,7 +42,9 @@ jobs:
       penultimate: ${{ steps.set-env.outputs.penultimate }}
       all: ${{ steps.set-matrix.outputs.all }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: 'false'
       - name: Set Go Versions
         id: set-env
         run: cat ./.github/variables/go-versions.env > $GITHUB_OUTPUT

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,8 +6,14 @@ on:
       - main
   workflow_dispatch:
 
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,12 @@ on:
     # Happen once per day at 1:30 AM
     - cron: '30 1 * * *'
 
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   sdk-close-stale:
     uses: launchdarkly/gh-actions/.github/workflows/sdk-stale.yml@main


### PR DESCRIPTION
Switch to using OctoSTS with a local trust policy in order to prevent having to close & re-open PRs, since GitHub actions isn't able to trigger it's own workflows. Also upgrade & pin actions versions, then run Zizmor against the workflow files for static analysis of actions code.