### PR TITLE
chore: add explicit permissions to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,5 +9,8 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4


### PR DESCRIPTION
## Summary

Adds explicit `contents: write` and `pull-requests: write` permissions to the `release-please` job. Without these, the release-please action may fail to create release PRs or GitHub releases if the repository's default token permissions are set to read-only.

## Review & Testing Checklist for Human

- [ ] Verify that no other permissions (e.g. `id-token: write`) are needed for the release-please action in this repo
- [ ] Confirm the repo's default workflow permissions setting — if already set to permissive, this change is a no-op but still good practice for explicitness

### Notes

This is part of a batch update across all `launchdarkly-sdk`-tagged repos that use release-please but were missing explicit workflow permissions on their default branch.

Link to Devin session: https://app.devin.ai/sessions/a83b6e4f4fa14b96b859cfb50755a2c1
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk YAML-only change that just grants `GITHUB_TOKEN` the minimal write permissions needed for release-please to open PRs and create releases.
> 
> **Overview**
> Adds explicit job-level `permissions` (`contents: write`, `pull-requests: write`) to the `release-please` GitHub Actions workflow so the release-please action can create release PRs/releases even when default token permissions are read-only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 261e5d80a48ea2c0957d3179a65343fa2a034cfe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->